### PR TITLE
[feat] Add Keycloak Scope Client CRUD

### DIFF
--- a/src/main/java/com/sd/KeycloakClient/client/admin/auth/async/KeycloakAuthScopeAsyncClient.java
+++ b/src/main/java/com/sd/KeycloakClient/client/admin/auth/async/KeycloakAuthScopeAsyncClient.java
@@ -1,0 +1,19 @@
+package com.sd.KeycloakClient.client.admin.auth.async;
+
+import com.sd.KeycloakClient.dto.KeycloakResponse;
+import com.sd.KeycloakClient.dto.admin.ScopeQueryParams;
+import org.keycloak.representations.idm.authorization.ScopeRepresentation;
+import reactor.core.publisher.Mono;
+
+public interface KeycloakAuthScopeAsyncClient {
+
+   Mono<KeycloakResponse<ScopeRepresentation>> getScope(String accessToken, String clientUuid, String scopeId);
+
+   Mono<KeycloakResponse<ScopeRepresentation[]>> getScopes(String accessToken, String clientUuid, ScopeQueryParams scopeQueryParams);
+
+   Mono<KeycloakResponse<Void>> createScope(String accessToken, String clientUuid, ScopeRepresentation scopeRepresentation);
+
+   Mono<KeycloakResponse<Void>> updateScope(String accessToken, String clientUuid, ScopeRepresentation scopeRepresentation);
+
+   Mono<KeycloakResponse<Void>> deleteScope(String accessToken, String clientUuid, String scopeId);
+}

--- a/src/main/java/com/sd/KeycloakClient/client/admin/auth/async/impl/KeycloakAuthScopeAsyncClientImpl.java
+++ b/src/main/java/com/sd/KeycloakClient/client/admin/auth/async/impl/KeycloakAuthScopeAsyncClientImpl.java
@@ -1,0 +1,89 @@
+package com.sd.KeycloakClient.client.admin.auth.async.impl;
+
+import com.sd.KeycloakClient.client.admin.auth.async.KeycloakAuthScopeAsyncClient;
+import com.sd.KeycloakClient.config.ClientConfiguration;
+import com.sd.KeycloakClient.dto.KeycloakResponse;
+import com.sd.KeycloakClient.dto.admin.ScopeQueryParams;
+import com.sd.KeycloakClient.http.Http;
+import org.keycloak.representations.idm.authorization.ScopeRepresentation;
+import reactor.core.publisher.Mono;
+
+public class KeycloakAuthScopeAsyncClientImpl implements KeycloakAuthScopeAsyncClient {
+
+   private final ClientConfiguration configuration;
+   private final Http http;
+
+   public KeycloakAuthScopeAsyncClientImpl(ClientConfiguration configuration) {
+      this.configuration = configuration;
+      this.http = new Http(configuration);
+   }
+
+   @Override
+   public Mono<KeycloakResponse<ScopeRepresentation>> getScope(
+       String accessToken,
+       String clientUuid,
+       String scopeId
+   ) {
+      return http.<ScopeRepresentation>get(configuration.getAuthScopeUrl(clientUuid, scopeId))
+          .authorizationBearer(accessToken)
+          .applicationJson()
+          .responseType(ScopeRepresentation.class)
+          .send();
+   }
+
+   @Override
+   public Mono<KeycloakResponse<ScopeRepresentation[]>> getScopes(
+       String accessToken,
+       String clientUuid,
+       ScopeQueryParams scopeQueryParams
+   ) {
+
+      return http.<ScopeRepresentation[]>get(configuration.getAuthScopeSearchUrl(clientUuid, scopeQueryParams.toQueryString()))
+          .authorizationBearer(accessToken)
+          .entities(scopeQueryParams)
+          .applicationJson()
+          .responseType(ScopeRepresentation[].class)
+          .send();
+   }
+
+   @Override
+   public Mono<KeycloakResponse<Void>> createScope(
+       String accessToken,
+       String clientUuid,
+       ScopeRepresentation scopeRepresentation
+   ) {
+      return http.<Void>post(configuration.getAuthScopeUrl(clientUuid))
+          .authorizationBearer(accessToken)
+          .entities(scopeRepresentation)
+          .applicationJson()
+          .responseType(Void.class)
+          .send();
+   }
+
+   @Override
+   public Mono<KeycloakResponse<Void>> updateScope(
+       String accessToken,
+       String clientUuid,
+       ScopeRepresentation scopeRepresentation
+   ) {
+      return http.<Void>put(configuration.getAuthScopeUrl(clientUuid, scopeRepresentation.getId()))
+          .authorizationBearer(accessToken)
+          .entities(scopeRepresentation)
+          .applicationJson()
+          .responseType(Void.class)
+          .send();
+   }
+
+   @Override
+   public Mono<KeycloakResponse<Void>> deleteScope(
+       String accessToken,
+       String clientUuid,
+       String scopeId
+   ) {
+      return http.<Void>delete(configuration.getAuthScopeUrl(clientUuid, scopeId))
+          .authorizationBearer(accessToken)
+          .applicationJson()
+          .responseType(Void.class)
+          .send();
+   }
+}

--- a/src/main/java/com/sd/KeycloakClient/client/admin/auth/sync/KeycloakAuthScopeClient.java
+++ b/src/main/java/com/sd/KeycloakClient/client/admin/auth/sync/KeycloakAuthScopeClient.java
@@ -1,0 +1,18 @@
+package com.sd.KeycloakClient.client.admin.auth.sync;
+
+import com.sd.KeycloakClient.dto.KeycloakResponse;
+import com.sd.KeycloakClient.dto.admin.ScopeQueryParams;
+import org.keycloak.representations.idm.authorization.ScopeRepresentation;
+
+public interface KeycloakAuthScopeClient {
+
+   KeycloakResponse<ScopeRepresentation> getScope(String accessToken, String clientUuid, String scopeId);
+
+   KeycloakResponse<ScopeRepresentation[]> getScopes(String accessToken, String clientUuid, ScopeQueryParams scopeQueryParams);
+
+   KeycloakResponse<Void> createScope(String accessToken, String clientUuid, ScopeRepresentation scopeRepresentation);
+
+   KeycloakResponse<Void> updateScope(String accessToken, String clientUuid, ScopeRepresentation scopeRepresentation);
+
+   KeycloakResponse<Void> deleteScope(String accessToken, String clientUuid, String scopeId);
+}

--- a/src/main/java/com/sd/KeycloakClient/client/admin/auth/sync/impl/KeycloakAuthScopeClientImpl.java
+++ b/src/main/java/com/sd/KeycloakClient/client/admin/auth/sync/impl/KeycloakAuthScopeClientImpl.java
@@ -1,0 +1,39 @@
+package com.sd.KeycloakClient.client.admin.auth.sync.impl;
+
+import com.sd.KeycloakClient.client.admin.auth.async.KeycloakAuthScopeAsyncClient;
+import com.sd.KeycloakClient.client.admin.auth.sync.KeycloakAuthScopeClient;
+import com.sd.KeycloakClient.dto.KeycloakResponse;
+import com.sd.KeycloakClient.dto.admin.ScopeQueryParams;
+import lombok.RequiredArgsConstructor;
+import org.keycloak.representations.idm.authorization.ScopeRepresentation;
+
+@RequiredArgsConstructor
+public class KeycloakAuthScopeClientImpl implements KeycloakAuthScopeClient {
+
+   private final KeycloakAuthScopeAsyncClient keycloakAuthScopeAsyncClient;
+
+   @Override
+   public KeycloakResponse<ScopeRepresentation> getScope(String accessToken, String clientUuid, String scopeId) {
+      return keycloakAuthScopeAsyncClient.getScope(accessToken, clientUuid, scopeId).block();
+   }
+
+   @Override
+   public KeycloakResponse<ScopeRepresentation[]> getScopes(String accessToken, String clientUuid, ScopeQueryParams scopeQueryParams) {
+      return keycloakAuthScopeAsyncClient.getScopes(accessToken, clientUuid, scopeQueryParams).block();
+   }
+
+   @Override
+   public KeycloakResponse<Void> createScope(String accessToken, String clientUuid, ScopeRepresentation scopeRepresentation) {
+      return keycloakAuthScopeAsyncClient.createScope(accessToken, clientUuid, scopeRepresentation).block();
+   }
+
+   @Override
+   public KeycloakResponse<Void> updateScope(String accessToken, String clientUuid, ScopeRepresentation scopeRepresentation) {
+      return keycloakAuthScopeAsyncClient.updateScope(accessToken, clientUuid, scopeRepresentation).block();
+   }
+
+   @Override
+   public KeycloakResponse<Void> deleteScope(String accessToken, String clientUuid, String scopeId) {
+      return keycloakAuthScopeAsyncClient.deleteScope(accessToken, clientUuid, scopeId).block();
+   }
+}

--- a/src/main/java/com/sd/KeycloakClient/config/ClientConfiguration.java
+++ b/src/main/java/com/sd/KeycloakClient/config/ClientConfiguration.java
@@ -37,6 +37,11 @@ public class ClientConfiguration {
    private static final String ROLE_MAPPING_PATH = "/role-mappings";
    private static final String COUNT_PATH = "/count";
    private static final String RESET_PASSWORD_PATH = "/reset-password";
+   private static final String AUTHZ_PATH = "/authz";
+   private static final String RESOURCE_SERVER_PATH = "/resource-server";
+   private static final String SCOPE_PATH = "/scope";
+   private static final String RESOURCE_PATH = "/resource";
+   private static final String PERMISSION_PATH = "/permission";
 
    private String getOidcUrl() {
       String oidcUrl = "";
@@ -144,5 +149,18 @@ public class ClientConfiguration {
 
    public String getResetPasswordUrl(String userId) {
       return getUserUrl(userId) + RESET_PASSWORD_PATH;
+   }
+
+   // === Authorization Scope ===
+   public String getAuthScopeUrl(String clientUuid) {
+      return getBaseClientsPath() + "/" + clientUuid + AUTHZ_PATH + RESOURCE_SERVER_PATH + SCOPE_PATH;
+   }
+
+   public String getAuthScopeUrl(String clientUuid, String scopeId) {
+      return getAuthScopeUrl(clientUuid) + "/" + scopeId;
+   }
+
+   public String getAuthScopeSearchUrl(String clientUuid, String queryParam) {
+      return attachQueryParam(getAuthScopeUrl(clientUuid), queryParam);
    }
 }

--- a/src/main/java/com/sd/KeycloakClient/dto/admin/ScopeQueryParams.java
+++ b/src/main/java/com/sd/KeycloakClient/dto/admin/ScopeQueryParams.java
@@ -1,0 +1,49 @@
+package com.sd.KeycloakClient.dto.admin;
+
+import static com.sd.KeycloakClient.util.UrlUtil.toUrlEncoded;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ScopeQueryParams {
+
+   /**
+    * Index of the first scope to return (used for pagination). Defaults to 0 if not specified.
+    */
+   private String first;
+   /**
+    * Maximum number of scopes to return (used for pagination).
+    */
+   private String max;
+   /**
+    * Name of the scope to filter by.
+    */
+   private String name;
+   /**
+    * Scope ID to filter by.
+    */
+   private String scopeId;
+
+   public String toQueryString() {
+      String queryParam = toUrlEncoded(Stream.of(
+              new SimpleEntry<>("first", first),
+              new SimpleEntry<>("max", max),
+              new SimpleEntry<>("name", name),
+              new SimpleEntry<>("scopeId", scopeId)
+          )
+          .filter(entry -> entry.getValue() != null)
+          .collect(Collectors.toMap(Entry::getKey, Entry::getValue)));
+
+      return queryParam.isEmpty() ? "" : "?" + queryParam;
+   }
+}

--- a/src/main/java/com/sd/KeycloakClient/factory/KeycloakClient.java
+++ b/src/main/java/com/sd/KeycloakClient/factory/KeycloakClient.java
@@ -1,5 +1,9 @@
 package com.sd.KeycloakClient.factory;
 
+import com.sd.KeycloakClient.client.admin.auth.async.KeycloakAuthScopeAsyncClient;
+import com.sd.KeycloakClient.client.admin.auth.async.impl.KeycloakAuthScopeAsyncClientImpl;
+import com.sd.KeycloakClient.client.admin.auth.sync.KeycloakAuthScopeClient;
+import com.sd.KeycloakClient.client.admin.auth.sync.impl.KeycloakAuthScopeClientImpl;
 import com.sd.KeycloakClient.client.admin.client.async.KeycloakClientsAsyncClient;
 import com.sd.KeycloakClient.client.admin.client.async.impl.KeycloakClientsAsyncClientImpl;
 import com.sd.KeycloakClient.client.admin.client.sync.KeycloakClientsClient;
@@ -40,6 +44,8 @@ public class KeycloakClient {
    private final KeycloakClientsClientImpl clientsClient;
    private final KeycloakRoleAsyncClientImpl roleAsyncClient;
    private final KeycloakRoleClientImpl roleClient;
+   private final KeycloakAuthScopeAsyncClientImpl authScopeAsyncClient;
+   private final KeycloakAuthScopeClientImpl authScopeClient;
 
    public KeycloakClient(final ClientConfiguration config) {
       this.authAsyncClient = new KeycloakAuthAsyncClientImpl(config);
@@ -52,6 +58,8 @@ public class KeycloakClient {
       this.clientsClient = new KeycloakClientsClientImpl(this.clientsAsyncClient);
       this.roleAsyncClient = new KeycloakRoleAsyncClientImpl(config);
       this.roleClient = new KeycloakRoleClientImpl(this.roleAsyncClient);
+      this.authScopeAsyncClient = new KeycloakAuthScopeAsyncClientImpl(config);
+      this.authScopeClient = new KeycloakAuthScopeClientImpl(this.authScopeAsyncClient);
    }
 
    public KeycloakAuthClient auth() {
@@ -92,5 +100,13 @@ public class KeycloakClient {
 
    public KeycloakRoleClient role() {
       return this.roleClient;
+   }
+
+   public KeycloakAuthScopeAsyncClient authScopeAsync() {
+      return this.authScopeAsyncClient;
+   }
+
+   public KeycloakAuthScopeClient authScope() {
+      return this.authScopeClient;
    }
 }

--- a/src/test/java/com/sd/KeycloakClient/client/admin/auth/async/impl/KeycloakAuthScopeAsyncClientImplTest.java
+++ b/src/test/java/com/sd/KeycloakClient/client/admin/auth/async/impl/KeycloakAuthScopeAsyncClientImplTest.java
@@ -1,0 +1,412 @@
+package com.sd.KeycloakClient.client.admin.auth.async.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.sd.KeycloakClient.annotation.MockKeycloakClient;
+import com.sd.KeycloakClient.common.KeycloakShareTestContainer;
+import com.sd.KeycloakClient.common.TestKeycloakTokenHolder;
+import com.sd.KeycloakClient.dto.KeycloakResponse;
+import com.sd.KeycloakClient.dto.admin.ScopeQueryParams;
+import com.sd.KeycloakClient.factory.KeycloakClient;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.idm.authorization.ScopeRepresentation;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@MockKeycloakClient
+class KeycloakAuthScopeAsyncClientImplTest extends KeycloakShareTestContainer {
+
+   private static KeycloakClient keycloakClient;
+
+   private String adminAccessToken;
+   private String accessToken;
+   private static final String clientUuid = "de5fe303-2e50-428e-ac72-b81d1dc5139a";
+   private static final String TEST_SCOPE_NAME = "GET";
+
+
+   @BeforeEach
+   void setup() {
+      adminAccessToken = TestKeycloakTokenHolder.getAdminAccessToken(keycloakClient);
+      accessToken = TestKeycloakTokenHolder.getAccessToken(keycloakClient);
+   }
+
+   @AfterAll
+   static void afterAll() {
+      TestKeycloakTokenHolder.removeAccessToken();
+      TestKeycloakTokenHolder.removeAdminAccessToken();
+   }
+
+   @DisplayName("case1. success case: get scope by scopeId")
+   @Test
+   void getScope() {
+      // given
+      Mono<String> ensureScopeId = keycloakClient.authScopeAsync()
+          .getScopes(adminAccessToken, clientUuid, ScopeQueryParams.builder().name(TEST_SCOPE_NAME).build()) // GET /scope/search?name=
+          .flatMap(list -> Mono.just(list.getBody().get()[0].getId()));
+
+      // when
+      Mono<KeycloakResponse<ScopeRepresentation>> whenGet =
+          ensureScopeId.flatMap(scopeId ->
+              keycloakClient.authScopeAsync().getScope(accessToken, clientUuid, scopeId));
+
+      // then
+      StepVerifier.create(whenGet)
+          .assertNext(resp -> {
+             assertThat(resp.getStatus()).isEqualTo(200);
+             assertThat(resp.getBody()).isPresent();
+
+             ScopeRepresentation body = resp.getBody().get();
+             assertThat(body.getId()).isNotBlank();
+             assertThat(body.getName()).isEqualTo(TEST_SCOPE_NAME);
+          })
+          .verifyComplete();
+   }
+
+   @DisplayName("case2. accessToken is null (401 Unauthorized)")
+   @Test
+   void getScopeAccessTokenNull() {
+      // given
+      Mono<KeycloakResponse<ScopeRepresentation>> scope = keycloakClient.authScopeAsync()
+          .getScope(null, "prm-client", "TEST_SCOPE_ID");
+      // when && then
+      StepVerifier.create(scope)
+          .assertNext(response -> {
+             assertThat(HttpResponseStatus.UNAUTHORIZED.code()).isEqualTo(response.getStatus());
+             assertThat(response.getBody()).isEmpty();
+             assertThat(response.getMessage()).contains("Unauthorized");
+          })
+          .verifyComplete();
+   }
+
+   @DisplayName("case3. clientUuid is null (404 Not Found)")
+   @Test
+   void getScopeClientUuidNull() {
+      // given
+      Mono<KeycloakResponse<ScopeRepresentation>> scope = keycloakClient.authScopeAsync()
+          .getScope(accessToken, null, "TEST_SCOPE_ID");
+      // when && then
+      StepVerifier.create(scope)
+          .assertNext(response -> {
+             assertThat(HttpResponseStatus.NOT_FOUND.code()).isEqualTo(response.getStatus());
+             assertThat(response.getBody()).isEmpty();
+             assertThat(response.getMessage()).contains("Not Found");
+          })
+          .verifyComplete();
+   }
+
+
+   @DisplayName("case4. success case: get scope by scopeId")
+   @Test
+   void getScopes() {
+      // given
+      Mono<KeycloakResponse<ScopeRepresentation[]>> scopeResponse = keycloakClient.authScopeAsync().getScopes(
+          adminAccessToken,
+          clientUuid,
+          ScopeQueryParams.builder().name(TEST_SCOPE_NAME).build()
+      );
+
+      StepVerifier.create(scopeResponse)
+          .assertNext(resp -> {
+             assertThat(resp.getStatus()).isEqualTo(200);
+             assertThat(resp.getBody()).isPresent();
+             ScopeRepresentation body = resp.getBody().get()[0];
+             assertThat(body.getId()).isNotBlank();
+             assertThat(body.getName()).isEqualTo(TEST_SCOPE_NAME);
+          })
+          .verifyComplete();
+   }
+
+   @DisplayName("case5. success case: get scopes with empty ScopeQueryParams")
+   @Test
+   void getScopesWithEmptyScopeQueryParams() {
+      // given
+      Mono<KeycloakResponse<ScopeRepresentation[]>> scopeResponse = keycloakClient.authScopeAsync().getScopes(
+          adminAccessToken,
+          clientUuid,
+          ScopeQueryParams.builder().build()
+      );
+
+      // when && then
+      StepVerifier.create(scopeResponse)
+          .assertNext(resp -> {
+             assertThat(resp.getStatus()).isEqualTo(200);
+             assertThat(resp.getBody()).isPresent();
+             assertThat(resp.getBody().get()).isNotEmpty();
+             assertThat(resp.getBody().get().length).isEqualTo(9);
+          })
+          .verifyComplete();
+   }
+
+   @DisplayName("case6. exception case: get scopes with null ScopeQueryParams")
+   @Test
+   void getScopesWithNullScopeQueryParams() {
+      // given
+      assertThrows(NullPointerException.class, () ->
+          keycloakClient.authScopeAsync().getScopes(adminAccessToken, clientUuid, null)
+      );
+   }
+
+
+   @DisplayName("case7. exception case: get scopes with null adminAccessToken")
+   @Test
+   void getScopesWithNullAdminAccessToken() {
+      // given
+      Mono<KeycloakResponse<ScopeRepresentation[]>> scopeResponse = keycloakClient.authScopeAsync().getScopes(
+          null,
+          clientUuid,
+          ScopeQueryParams.builder().name(TEST_SCOPE_NAME).build()
+      );
+
+      // when && then
+      StepVerifier.create(scopeResponse)
+          .assertNext(response -> {
+             assertThat(HttpResponseStatus.UNAUTHORIZED.code()).isEqualTo(response.getStatus());
+             assertThat(response.getBody()).isEmpty();
+             assertThat(response.getMessage()).contains("Unauthorized");
+          })
+          .verifyComplete();
+   }
+
+   @DisplayName("case8. success case: create scope")
+   @Test
+   void createScope() {
+      // given
+      String testName = "TestScope";
+      String testIconUri = "http://example.com/icon.png";
+      String testDisplayName = "This is a test scope";
+      ScopeRepresentation newScope = new ScopeRepresentation();
+      newScope.setName(testName);
+      newScope.setIconUri(testIconUri);
+      newScope.setDisplayName(testDisplayName);
+      Mono<KeycloakResponse<Void>> scopeResponse = keycloakClient.authScopeAsync().createScope(
+          adminAccessToken,
+          clientUuid,
+          newScope
+      );
+
+      // when
+      StepVerifier.create(scopeResponse)
+          .assertNext(resp -> {
+             assertThat(resp.getStatus()).isEqualTo(201);
+             assertThat(resp.getBody()).isEmpty();
+          })
+          .verifyComplete();
+
+      // then
+      Mono<KeycloakResponse<ScopeRepresentation[]>> getScopesResponse = keycloakClient.authScopeAsync().getScopes(
+          adminAccessToken,
+          clientUuid,
+          ScopeQueryParams.builder().name(testName).build()
+      );
+      StepVerifier.create(getScopesResponse)
+          .assertNext(resp -> {
+             assertThat(resp.getStatus()).isEqualTo(200);
+             assertThat(resp.getBody()).isPresent();
+             ScopeRepresentation[] scopes = resp.getBody().get();
+             assertThat(scopes).isNotEmpty();
+             assertThat(scopes[0].getName()).isEqualTo(testName);
+             assertThat(scopes[0].getIconUri()).isEqualTo(testIconUri);
+             assertThat(scopes[0].getDisplayName()).isEqualTo(testDisplayName);
+          })
+          .verifyComplete();
+   }
+
+   @DisplayName("case9. exception case: create scope with null clientUuid")
+   @Test
+   void createScopeWithNullClientUuid() {
+      // given
+      ScopeRepresentation newScope = new ScopeRepresentation();
+      newScope.setName("TestScope");
+      Mono<KeycloakResponse<Void>> scopeResponse = keycloakClient.authScopeAsync().createScope(
+          adminAccessToken,
+          null,
+          newScope
+      );
+
+      // when && then
+      StepVerifier.create(scopeResponse)
+          .assertNext(response -> {
+             assertThat(HttpResponseStatus.NOT_FOUND.code()).isEqualTo(response.getStatus());
+             assertThat(response.getBody()).isEmpty();
+             assertThat(response.getMessage()).contains("Not Found");
+          })
+          .verifyComplete();
+   }
+
+   @DisplayName("case10. success case: create scope with empty ScopeRepresentation")
+   @Test
+   void createScopeWithEmptyScopeRepresentation() {
+      // given
+      ScopeRepresentation newScope = new ScopeRepresentation();
+      keycloakClient.authScopeAsync().createScope(
+          adminAccessToken,
+          clientUuid,
+          newScope
+      ).block();
+
+      // when & then
+      Mono<KeycloakResponse<ScopeRepresentation[]>> getScopesResponse = keycloakClient.authScopeAsync().getScopes(
+          adminAccessToken,
+          clientUuid,
+          ScopeQueryParams.builder().name(newScope.getName()).build()
+      );
+      StepVerifier.create(getScopesResponse)
+          .assertNext(resp -> {
+             assertThat(resp.getStatus()).isEqualTo(200);
+             assertThat(resp.getBody()).isPresent();
+             ScopeRepresentation[] scopes = resp.getBody().get();
+             assertThat(scopes).isNotEmpty();
+             assertThat(scopes[0].getId()).isNotBlank();
+          })
+          .verifyComplete();
+   }
+
+   @DisplayName("case11. exception case: create scope with null name")
+   @Test
+   void createScopeWithNullName() {
+      // given
+      ScopeRepresentation newScope = new ScopeRepresentation();
+      newScope.setName(null);
+      Mono<KeycloakResponse<Void>> scopeResponse = keycloakClient.authScopeAsync().createScope(
+          adminAccessToken,
+          clientUuid,
+          newScope
+      );
+
+      // when && then
+      StepVerifier.create(scopeResponse)
+          .assertNext(response -> {
+             assertThat(HttpResponseStatus.CONFLICT.code()).isEqualTo(response.getStatus());
+             assertThat(response.getBody()).isEmpty();
+             assertThat(response.getMessage()).contains("unknown_error");
+          })
+          .verifyComplete();
+   }
+
+
+   @Test
+   @DisplayName("case12. success case: update scope")
+   void updateScope() {
+
+      // given : before create a new scope
+      String newScopeName = "TestScopeToUpdate";
+      String updateScopeName = "UpdatedScopeName";
+      ScopeRepresentation newScope = new ScopeRepresentation();
+      newScope.setName(newScopeName);
+
+      keycloakClient.authScopeAsync().createScope(
+          adminAccessToken,
+          clientUuid,
+          newScope
+      ).block();
+
+      // scope get ScopeRepresentation
+      ScopeRepresentation getScope = keycloakClient.authScopeAsync()
+          .getScopes(adminAccessToken, clientUuid,
+              ScopeQueryParams.builder().name(newScope.getName()).build())
+          .map(KeycloakResponse::getBody)
+          .switchIfEmpty(Mono.error(new IllegalStateException("empty body")))
+          .block(Duration.ofSeconds(5))
+          .get()[0];
+      getScope.setName(updateScopeName);
+
+      // when: update the created scope, then verify the update
+      Mono<KeycloakResponse<Void>> updateScope = keycloakClient.authScopeAsync().updateScope(
+          adminAccessToken,
+          clientUuid,
+          getScope);
+      StepVerifier.create(updateScope)
+          .assertNext(response -> {
+             assertThat(response.getStatus()).isEqualTo(204);
+             assertThat(response.getBody()).isEmpty();
+          })
+          .verifyComplete();
+   }
+
+   @Test
+   @DisplayName("case13. exception case: update scope with null accessToken")
+   void updateScopeWithNullAccessToken() {
+      // given
+      ScopeRepresentation scopeToUpdate = new ScopeRepresentation();
+      scopeToUpdate.setName("ScopeToUpdate");
+
+      // when
+      Mono<KeycloakResponse<Void>> updateScope = keycloakClient.authScopeAsync().updateScope(
+          null, // accessToken is null
+          clientUuid,
+          scopeToUpdate);
+
+      // then
+      StepVerifier.create(updateScope)
+          .assertNext(response -> {
+             assertThat(HttpResponseStatus.UNAUTHORIZED.code()).isEqualTo(response.getStatus());
+             assertThat(response.getBody()).isEmpty();
+             assertThat(response.getMessage()).contains("Unauthorized");
+          })
+          .verifyComplete();
+   }
+
+   // deleteScope 200 OK
+   @Test
+   @DisplayName("case14. success case: delete scope")
+   void deleteScopeSuccess() {
+      // given : create a new scope
+      String scopeName = "ScopeToDelete";
+      ScopeRepresentation newScope = new ScopeRepresentation();
+      newScope.setName(scopeName);
+
+      keycloakClient.authScopeAsync().createScope(
+          adminAccessToken,
+          clientUuid,
+          newScope
+      ).block();
+      String scopeId = keycloakClient.authScopeAsync().getScopes(
+          accessToken,
+          clientUuid,
+          ScopeQueryParams.builder().name(scopeName).build()
+      ).block().getBody().get()[0].getId();// Ensure the scope is created
+
+      // then: delete the created scope
+      Mono<KeycloakResponse<Void>> deleteScopeResponse = keycloakClient.authScopeAsync().deleteScope(
+          adminAccessToken,
+          clientUuid,
+          scopeId
+      );
+
+      StepVerifier.create(deleteScopeResponse)
+          .assertNext(response -> {
+             assertThat(response.getStatus()).isEqualTo(204);
+             assertThat(response.getBody()).isEmpty();
+          })
+          .verifyComplete();
+   }
+
+   @Test
+   @DisplayName("case15. exception case: delete scope with null accessToken")
+   void deleteScopeWithNullAccessToken() {
+      // given
+      String scopeId = "test-scope-id";
+
+      // when
+      Mono<KeycloakResponse<Void>> deleteScopeResponse = keycloakClient.authScopeAsync().deleteScope(
+          null, // accessToken is null
+          clientUuid,
+          scopeId
+      );
+
+      // then
+      StepVerifier.create(deleteScopeResponse)
+          .assertNext(response -> {
+             assertThat(HttpResponseStatus.UNAUTHORIZED.code()).isEqualTo(response.getStatus());
+             assertThat(response.getBody()).isEmpty();
+             assertThat(response.getMessage()).contains("Unauthorized");
+          })
+          .verifyComplete();
+   }
+}

--- a/src/test/java/com/sd/KeycloakClient/config/ClientConfigurationTest.java
+++ b/src/test/java/com/sd/KeycloakClient/config/ClientConfigurationTest.java
@@ -1,0 +1,61 @@
+package com.sd.KeycloakClient.config;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ClientConfigurationTest {
+
+   private static final String BASE_URL = "http://localhost:8080";
+   private static final String REALM_NAME = "test-realm";
+   private static final String RELATIVE_PATH = "keycloak";
+   private static final String CLIENT_ID = "prm-client";
+   private static final String REDIRECT_URI = "http://localhost:8080/callback";
+   private static final String LOGOUT_REDIRECT_URI = "http://localhost:8080/logout";
+   private static final String RESPONSE_TYPE = "code";
+   private static final String CLIENT_SECRET = "test-client-secret";
+
+
+   private static final ClientConfiguration clientConfiguration = ClientConfiguration.builder()
+       .baseUrl(BASE_URL)
+       .realmName(REALM_NAME)
+       .relativePath(RELATIVE_PATH)
+       .clientId(CLIENT_ID)
+       .redirectUri(REDIRECT_URI)
+       .logoutRedirectUri(LOGOUT_REDIRECT_URI)
+       .responseType(RESPONSE_TYPE)
+       .clientSecret(CLIENT_SECRET)
+       .build();
+   private static final String SCOPE_UUID = "test-scope-uuid";
+
+   @Test
+   @DisplayName("case1. success case: get token url")
+   void getAuthScopeUrl() {
+      String authScopeUrl = clientConfiguration.getAuthScopeUrl(CLIENT_ID);
+      final String expectedUrl =
+          RELATIVE_PATH + "/admin/realms/" + clientConfiguration.getRealmName() + "/clients/" + CLIENT_ID + "/authz/resource-server/scope";
+
+      Assertions.assertEquals(authScopeUrl, expectedUrl);
+   }
+
+   @Test
+   @DisplayName("case2. success case: get auth scope url with scope uuid")
+   void getAuthScopeUrlWithScopeUuid() {
+      String authScopeUrl = clientConfiguration.getAuthScopeUrl(CLIENT_ID, SCOPE_UUID);
+      final String expectedUrl =
+          RELATIVE_PATH + "/admin/realms/" + clientConfiguration.getRealmName() + "/clients/" + CLIENT_ID + "/authz/resource-server/scope/"
+              + SCOPE_UUID;
+
+      Assertions.assertEquals(authScopeUrl, expectedUrl);
+   }
+
+   @Test
+   @DisplayName("case3. success case: get auth scope search url with query params")
+   void getAuthScopeSearchUrl() {
+      String authScopeSearchUrl = clientConfiguration.getAuthScopeSearchUrl(CLIENT_ID, "?name=test");
+      final String expectedUrl =
+          RELATIVE_PATH + "/admin/realms/" + clientConfiguration.getRealmName() + "/clients/" + CLIENT_ID
+              + "/authz/resource-server/scope?name=test";
+      Assertions.assertEquals(authScopeSearchUrl, expectedUrl);
+   }
+}

--- a/src/test/java/com/sd/KeycloakClient/dto/admin/ScopeQueryParamsTest.java
+++ b/src/test/java/com/sd/KeycloakClient/dto/admin/ScopeQueryParamsTest.java
@@ -1,0 +1,49 @@
+package com.sd.KeycloakClient.dto.admin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ScopeQueryParamsTest {
+
+
+   @Nested
+   @DisplayName("toQueryString test cases")
+   class toQueryString {
+
+      @Test
+      @DisplayName("case1. no parameters provided, should return empty query string")
+      void toQueryString_noParams() {
+         ScopeQueryParams scopeQueryParams = new ScopeQueryParams();
+         String queryString = scopeQueryParams.toQueryString();
+
+         assertTrue(queryString.isEmpty());
+      }
+
+      @Test
+      @DisplayName("case2. with parameters provided, should return query string")
+      void toQueryString_withParams() {
+         ScopeQueryParams scopeQueryParams =
+             ScopeQueryParams.builder()
+                 .first("0")
+                 .max("100")
+                 .build();
+
+         String queryString = scopeQueryParams.toQueryString();
+
+         String[] parts = queryString.substring(1).split("&");
+         Map<String, String> paramMap = Arrays.stream(parts)
+             .map(s -> s.split("="))
+             .collect(Collectors.toMap(arr -> arr[0], arr -> arr[1]));
+
+         assertEquals("0", paramMap.get("first"));
+         assertEquals("100", paramMap.get("max"));
+      }
+   }
+}

--- a/src/test/resources/realm.json
+++ b/src/test/resources/realm.json
@@ -770,15 +770,27 @@
             "iconUri": ""
           },
           {
-            "name": "order",
-            "iconUri": ""
-          },
-          {
             "name": "PUT",
             "iconUri": ""
           },
           {
             "name": "POST",
+            "iconUri": ""
+          },
+          {
+            "name": "OPTIONS",
+            "iconUri": ""
+          },
+          {
+            "name": "HEAD",
+            "iconUri": ""
+          },
+          {
+            "name": "CONNECT",
+            "iconUri": ""
+          },
+          {
+            "name": "TRACE",
             "iconUri": ""
           }
         ],


### PR DESCRIPTION

## 📝 Work Done
- [x] Added `KeycloakAuthScopeAsyncClient` interface (CRUD methods)
- [x] Implemented `KeycloakAuthScopeAsyncClientImpl` with WebFlux
- [x] Added `KeycloakAuthScopeClient` and sync implementation using `block()`
- [x] Updated `ClientConfiguration` with scope URL methods
- [x] Created `ScopeQueryParams` DTO and query string builder
- [x] Updated `KeycloakClient` factory to include scope clients
- [x] Added unit tests (`ScopeQueryParamsTest`, `ClientConfigurationTest`)
- [x] Updated `realm.json` with new scope resources

---

## 💡 Review Points
1. Check if scope CRUD URLs and params in `ClientConfiguration` are correct.
2. Make sure `ScopeQueryParams.toQueryString()` creates clear and correct query strings.
3. Review if using `block()` in sync client is safe and reasonable.
4. See if test cases cover enough edge cases (empty params, invalid values, etc.).

---

## 📂 Changed Files
1. `KeycloakAuthScopeAsyncClient.java`: async client interface
2. `KeycloakAuthScopeAsyncClientImpl.java`: async implementation (CRUD APIs)
3. `KeycloakAuthScopeClient.java`: sync client interface
4. `KeycloakAuthScopeClientImpl.java`: sync implementation (`block()`)
5. `ClientConfiguration.java`: added scope URL methods
6. `ScopeQueryParams.java`: DTO for search params + query builder
7. `KeycloakClient.java`: added scope clients in factory
8. `ClientConfigurationTest.java`: test for scope URLs
9. `ScopeQueryParamsTest.java`: test for query string
10. `realm.json`: added scope resource changes

---

## 🚨 Other Notes
- Need to decide how to handle errors when creating or deleting scopes.
- Mixed use of `Mono` and `block()` may cause issues depending on app runtime (reactive vs blocking).
