### PR TITLE
[refactor] UUID 기반 파라미터 검증·타입 전환 및 공통 실패 응답 정리

### DIFF
--- a/src/main/java/com/sd/KeycloakClient/client/admin/auth/async/KeycloakAuthScopeAsyncClient.java
+++ b/src/main/java/com/sd/KeycloakClient/client/admin/auth/async/KeycloakAuthScopeAsyncClient.java
@@ -2,6 +2,7 @@ package com.sd.KeycloakClient.client.admin.auth.async;
 
 import com.sd.KeycloakClient.dto.KeycloakResponse;
 import com.sd.KeycloakClient.dto.admin.ScopeQueryParams;
+import java.util.UUID;
 import org.keycloak.representations.idm.authorization.ScopeRepresentation;
 import reactor.core.publisher.Mono;
 
@@ -20,7 +21,7 @@ public interface KeycloakAuthScopeAsyncClient {
     * @param scopeId     the unique identifier of the scope to retrieve
     * @return a {@link Mono} emitting a {@link KeycloakResponse} containing the {@link ScopeRepresentation} if found
     */
-   Mono<KeycloakResponse<ScopeRepresentation>> getScope(String accessToken, String clientUuid, String scopeId);
+   Mono<KeycloakResponse<ScopeRepresentation>> getScope(String accessToken, UUID clientUuid, UUID scopeId);
 
    /**
     * Retrieve a list of authorization scopes, optionally filtered by query parameters.
@@ -30,7 +31,7 @@ public interface KeycloakAuthScopeAsyncClient {
     * @param scopeQueryParams optional filtering and pagination parameters
     * @return a {@link Mono} emitting a {@link KeycloakResponse} containing an array of {@link ScopeRepresentation} objects
     */
-   Mono<KeycloakResponse<ScopeRepresentation[]>> getScopes(String accessToken, String clientUuid, ScopeQueryParams scopeQueryParams);
+   Mono<KeycloakResponse<ScopeRepresentation[]>> getScopes(String accessToken, UUID clientUuid, ScopeQueryParams scopeQueryParams);
 
    /**
     * @param accessToken         access token
@@ -38,7 +39,7 @@ public interface KeycloakAuthScopeAsyncClient {
     * @param scopeRepresentation scope representation
     * @return
     */
-   Mono<KeycloakResponse<Void>> createScope(String accessToken, String clientUuid, ScopeRepresentation scopeRepresentation);
+   Mono<KeycloakResponse<Void>> createScope(String accessToken, UUID clientUuid, ScopeRepresentation scopeRepresentation);
 
    /**
     * Update an existing authorization scope.
@@ -48,7 +49,7 @@ public interface KeycloakAuthScopeAsyncClient {
     * @param scopeRepresentation the updated scope definition (must include the ID)
     * @return a {@link Mono} emitting a {@link KeycloakResponse} with no body (success or failure status only)
     */
-   Mono<KeycloakResponse<Void>> updateScope(String accessToken, String clientUuid, ScopeRepresentation scopeRepresentation);
+   Mono<KeycloakResponse<Void>> updateScope(String accessToken, UUID clientUuid, ScopeRepresentation scopeRepresentation);
 
    /**
     * Delete an authorization scope by its ID.
@@ -58,5 +59,5 @@ public interface KeycloakAuthScopeAsyncClient {
     * @param scopeId     the unique identifier of the scope to delete
     * @return a {@link Mono} emitting a {@link KeycloakResponse} with no body (success or failure status only)
     */
-   Mono<KeycloakResponse<Void>> deleteScope(String accessToken, String clientUuid, String scopeId);
+   Mono<KeycloakResponse<Void>> deleteScope(String accessToken, UUID clientUuid, UUID scopeId);
 }

--- a/src/main/java/com/sd/KeycloakClient/client/admin/auth/sync/KeycloakAuthScopeClient.java
+++ b/src/main/java/com/sd/KeycloakClient/client/admin/auth/sync/KeycloakAuthScopeClient.java
@@ -2,6 +2,7 @@ package com.sd.KeycloakClient.client.admin.auth.sync;
 
 import com.sd.KeycloakClient.dto.KeycloakResponse;
 import com.sd.KeycloakClient.dto.admin.ScopeQueryParams;
+import java.util.UUID;
 import org.keycloak.representations.idm.authorization.ScopeRepresentation;
 
 /**
@@ -19,7 +20,7 @@ public interface KeycloakAuthScopeClient {
     * @param scopeId     the unique identifier of the scope to retrieve
     * @return a {@link KeycloakResponse} containing the {@link ScopeRepresentation} if found
     */
-   KeycloakResponse<ScopeRepresentation> getScope(String accessToken, String clientUuid, String scopeId);
+   KeycloakResponse<ScopeRepresentation> getScope(String accessToken, UUID clientUuid, UUID scopeId);
 
    /**
     * Retrieve a list of authorization scopes, optionally filtered by query parameters.
@@ -29,7 +30,7 @@ public interface KeycloakAuthScopeClient {
     * @param scopeQueryParams optional filtering and pagination parameters
     * @return a {@link KeycloakResponse} containing an array of {@link ScopeRepresentation} objects
     */
-   KeycloakResponse<ScopeRepresentation[]> getScopes(String accessToken, String clientUuid, ScopeQueryParams scopeQueryParams);
+   KeycloakResponse<ScopeRepresentation[]> getScopes(String accessToken, UUID clientUuid, ScopeQueryParams scopeQueryParams);
 
    /**
     * Create a new authorization scope for the given client.
@@ -39,7 +40,7 @@ public interface KeycloakAuthScopeClient {
     * @param scopeRepresentation the scope definition to be created
     * @return a {@link KeycloakResponse} with no body (success or failure status only)
     */
-   KeycloakResponse<Void> createScope(String accessToken, String clientUuid, ScopeRepresentation scopeRepresentation);
+   KeycloakResponse<Void> createScope(String accessToken, UUID clientUuid, ScopeRepresentation scopeRepresentation);
 
    /**
     * Update an existing authorization scope.
@@ -49,7 +50,7 @@ public interface KeycloakAuthScopeClient {
     * @param scopeRepresentation the updated scope definition (must include the ID)
     * @return a {@link KeycloakResponse} with no body (success or failure status only)
     */
-   KeycloakResponse<Void> updateScope(String accessToken, String clientUuid, ScopeRepresentation scopeRepresentation);
+   KeycloakResponse<Void> updateScope(String accessToken, UUID clientUuid, ScopeRepresentation scopeRepresentation);
 
    /**
     * Delete an authorization scope by its ID.
@@ -59,5 +60,5 @@ public interface KeycloakAuthScopeClient {
     * @param scopeId     the unique identifier of the scope to delete
     * @return a {@link KeycloakResponse} with no body (success or failure status only)
     */
-   KeycloakResponse<Void> deleteScope(String accessToken, String clientUuid, String scopeId);
+   KeycloakResponse<Void> deleteScope(String accessToken, UUID clientUuid, UUID scopeId);
 }

--- a/src/main/java/com/sd/KeycloakClient/client/admin/auth/sync/impl/KeycloakAuthScopeClientImpl.java
+++ b/src/main/java/com/sd/KeycloakClient/client/admin/auth/sync/impl/KeycloakAuthScopeClientImpl.java
@@ -4,6 +4,7 @@ import com.sd.KeycloakClient.client.admin.auth.async.KeycloakAuthScopeAsyncClien
 import com.sd.KeycloakClient.client.admin.auth.sync.KeycloakAuthScopeClient;
 import com.sd.KeycloakClient.dto.KeycloakResponse;
 import com.sd.KeycloakClient.dto.admin.ScopeQueryParams;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.keycloak.representations.idm.authorization.ScopeRepresentation;
 
@@ -13,27 +14,27 @@ public class KeycloakAuthScopeClientImpl implements KeycloakAuthScopeClient {
    private final KeycloakAuthScopeAsyncClient keycloakAuthScopeAsyncClient;
 
    @Override
-   public KeycloakResponse<ScopeRepresentation> getScope(String accessToken, String clientUuid, String scopeId) {
+   public KeycloakResponse<ScopeRepresentation> getScope(String accessToken, UUID clientUuid, UUID scopeId) {
       return keycloakAuthScopeAsyncClient.getScope(accessToken, clientUuid, scopeId).block();
    }
 
    @Override
-   public KeycloakResponse<ScopeRepresentation[]> getScopes(String accessToken, String clientUuid, ScopeQueryParams scopeQueryParams) {
+   public KeycloakResponse<ScopeRepresentation[]> getScopes(String accessToken, UUID clientUuid, ScopeQueryParams scopeQueryParams) {
       return keycloakAuthScopeAsyncClient.getScopes(accessToken, clientUuid, scopeQueryParams).block();
    }
 
    @Override
-   public KeycloakResponse<Void> createScope(String accessToken, String clientUuid, ScopeRepresentation scopeRepresentation) {
+   public KeycloakResponse<Void> createScope(String accessToken, UUID clientUuid, ScopeRepresentation scopeRepresentation) {
       return keycloakAuthScopeAsyncClient.createScope(accessToken, clientUuid, scopeRepresentation).block();
    }
 
    @Override
-   public KeycloakResponse<Void> updateScope(String accessToken, String clientUuid, ScopeRepresentation scopeRepresentation) {
+   public KeycloakResponse<Void> updateScope(String accessToken, UUID clientUuid, ScopeRepresentation scopeRepresentation) {
       return keycloakAuthScopeAsyncClient.updateScope(accessToken, clientUuid, scopeRepresentation).block();
    }
 
    @Override
-   public KeycloakResponse<Void> deleteScope(String accessToken, String clientUuid, String scopeId) {
+   public KeycloakResponse<Void> deleteScope(String accessToken, UUID clientUuid, UUID scopeId) {
       return keycloakAuthScopeAsyncClient.deleteScope(accessToken, clientUuid, scopeId).block();
    }
 }

--- a/src/main/java/com/sd/KeycloakClient/client/admin/role/async/KeycloakRoleAsyncClient.java
+++ b/src/main/java/com/sd/KeycloakClient/client/admin/role/async/KeycloakRoleAsyncClient.java
@@ -2,20 +2,21 @@ package com.sd.KeycloakClient.client.admin.role.async;
 
 import com.sd.KeycloakClient.dto.KeycloakResponse;
 import com.sd.KeycloakClient.dto.admin.RoleQueryParams;
+import java.util.UUID;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import reactor.core.publisher.Mono;
 
 public interface KeycloakRoleAsyncClient {
 
-   Mono<KeycloakResponse<RoleRepresentation[]>> getRoles(String accessToken, String clientUuid, RoleQueryParams queryParams);
+   Mono<KeycloakResponse<RoleRepresentation[]>> getRoles(String accessToken, UUID clientUuid, RoleQueryParams queryParams);
 
-   Mono<KeycloakResponse<RoleRepresentation[]>> getUserRole(String accessToken, String userId, String clientUuid);
+   Mono<KeycloakResponse<RoleRepresentation[]>> getUserRole(String accessToken, UUID userId, UUID clientUuid);
 
-   Mono<KeycloakResponse<UserRepresentation[]>> getUsersByClientRoleName(String accessToken, String roleName, String clientUuid,
+   Mono<KeycloakResponse<UserRepresentation[]>> getUsersByClientRoleName(String accessToken, String roleName, UUID clientUuid,
        Boolean briefRepresentation, Integer first, Integer max);
 
-   Mono<KeycloakResponse<Void>> grantRole(String accessToken, String userId, String clientUuid, RoleRepresentation[] role);
+   Mono<KeycloakResponse<Void>> grantRole(String accessToken, UUID userId, UUID clientUuid, RoleRepresentation[] role);
 
-   Mono<KeycloakResponse<Void>> removeRole(String accessToken, String userId, String clientUuid, RoleRepresentation[] role);
+   Mono<KeycloakResponse<Void>> removeRole(String accessToken, UUID userId, UUID clientUuid, RoleRepresentation[] role);
 }

--- a/src/main/java/com/sd/KeycloakClient/client/admin/role/async/impl/KeycloakRoleAsyncClientImpl.java
+++ b/src/main/java/com/sd/KeycloakClient/client/admin/role/async/impl/KeycloakRoleAsyncClientImpl.java
@@ -8,6 +8,7 @@ import com.sd.KeycloakClient.http.Http;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.UUID;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import reactor.core.publisher.Mono;
@@ -23,7 +24,7 @@ public class KeycloakRoleAsyncClientImpl implements KeycloakRoleAsyncClient {
    }
 
    @Override
-   public Mono<KeycloakResponse<RoleRepresentation[]>> getRoles(String accessToken, String clientUuid, RoleQueryParams queryParams) {
+   public Mono<KeycloakResponse<RoleRepresentation[]>> getRoles(String accessToken, UUID clientUuid, RoleQueryParams queryParams) {
       String rolesUrl = configuration.getRolesUrl(clientUuid, queryParams.toQueryString());
       return http.<RoleRepresentation[]>get(rolesUrl)
           .applicationJson()
@@ -33,7 +34,7 @@ public class KeycloakRoleAsyncClientImpl implements KeycloakRoleAsyncClient {
    }
 
    @Override
-   public Mono<KeycloakResponse<RoleRepresentation[]>> getUserRole(String accessToken, String userId, String clientUuid) {
+   public Mono<KeycloakResponse<RoleRepresentation[]>> getUserRole(String accessToken, UUID userId, UUID clientUuid) {
       String rolesUrl = configuration.getRoleMappingPath(userId, clientUuid);
       return http.<RoleRepresentation[]>get(rolesUrl)
           .applicationJson()
@@ -44,7 +45,7 @@ public class KeycloakRoleAsyncClientImpl implements KeycloakRoleAsyncClient {
 
    @Override
    public Mono<KeycloakResponse<UserRepresentation[]>> getUsersByClientRoleName(String accessToken, String roleName,
-       String clientUuid, Boolean briefRepresentation, Integer first, Integer max) {
+       UUID clientUuid, Boolean briefRepresentation, Integer first, Integer max) {
       String clientsUsers = configuration.getClientsRolesUsersPath(clientUuid, roleName, briefRepresentation, first, max);
 
       return http.<UserRepresentation[]>get(clientsUsers)
@@ -55,7 +56,7 @@ public class KeycloakRoleAsyncClientImpl implements KeycloakRoleAsyncClient {
    }
 
    @Override
-   public Mono<KeycloakResponse<Void>> grantRole(String accessToken, String userId, String clientUuid,
+   public Mono<KeycloakResponse<Void>> grantRole(String accessToken, UUID userId, UUID clientUuid,
        RoleRepresentation[] roles) {
       String roleMappingPath = configuration.getRoleMappingPath(userId, clientUuid);
       boolean notFoundAttribute = Arrays.stream(roles).anyMatch(role -> Objects.isNull(role.getName()) || Objects.isNull(role.getId()));
@@ -71,7 +72,7 @@ public class KeycloakRoleAsyncClientImpl implements KeycloakRoleAsyncClient {
    }
 
    @Override
-   public Mono<KeycloakResponse<Void>> removeRole(String accessToken, String userId, String clientUuid,
+   public Mono<KeycloakResponse<Void>> removeRole(String accessToken, UUID userId, UUID clientUuid,
        RoleRepresentation[] roles) {
       String roleMappingPath = configuration.getRoleMappingPath(userId, clientUuid);
       boolean notFoundAttribute = Arrays.stream(roles).anyMatch(role -> Objects.isNull(role.getName()) || Objects.isNull(role.getId()));

--- a/src/main/java/com/sd/KeycloakClient/client/admin/role/sync/KeycloakRoleClient.java
+++ b/src/main/java/com/sd/KeycloakClient/client/admin/role/sync/KeycloakRoleClient.java
@@ -2,19 +2,20 @@ package com.sd.KeycloakClient.client.admin.role.sync;
 
 import com.sd.KeycloakClient.dto.KeycloakResponse;
 import com.sd.KeycloakClient.dto.admin.RoleQueryParams;
+import java.util.UUID;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 
 public interface KeycloakRoleClient {
 
-   KeycloakResponse<RoleRepresentation[]> getRoles(String accessToken, String clientUuid, RoleQueryParams queryParams);
+   KeycloakResponse<RoleRepresentation[]> getRoles(String accessToken, UUID clientUuid, RoleQueryParams queryParams);
 
-   KeycloakResponse<RoleRepresentation[]> getUserRole(String accessToken, String userId, String clientUuid);
+   KeycloakResponse<RoleRepresentation[]> getUserRole(String accessToken, UUID userId, UUID clientUuid);
 
-   KeycloakResponse<Void> grantRole(String accessToken, String userId, String clientUuid, RoleRepresentation[] role);
+   KeycloakResponse<Void> grantRole(String accessToken, UUID userId, UUID clientUuid, RoleRepresentation[] role);
 
-   KeycloakResponse<Void> removeRole(String accessToken, String userId, String clientUuid, RoleRepresentation[] role);
+   KeycloakResponse<Void> removeRole(String accessToken, UUID userId, UUID clientUuid, RoleRepresentation[] role);
 
-   KeycloakResponse<UserRepresentation[]> getUsersByClientRoleName(String accessToken, String roleName, String clientUuid,
+   KeycloakResponse<UserRepresentation[]> getUsersByClientRoleName(String accessToken, String roleName, UUID clientUuid,
        Boolean briefRepresentation, Integer first, Integer max);
 }

--- a/src/main/java/com/sd/KeycloakClient/client/admin/role/sync/impl/KeycloakRoleClientImpl.java
+++ b/src/main/java/com/sd/KeycloakClient/client/admin/role/sync/impl/KeycloakRoleClientImpl.java
@@ -4,6 +4,7 @@ import com.sd.KeycloakClient.client.admin.role.async.KeycloakRoleAsyncClient;
 import com.sd.KeycloakClient.client.admin.role.sync.KeycloakRoleClient;
 import com.sd.KeycloakClient.dto.KeycloakResponse;
 import com.sd.KeycloakClient.dto.admin.RoleQueryParams;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -14,27 +15,27 @@ public class KeycloakRoleClientImpl implements KeycloakRoleClient {
    private final KeycloakRoleAsyncClient keycloakRoleClient;
 
    @Override
-   public KeycloakResponse<RoleRepresentation[]> getRoles(String accessToken, String clientUuid, RoleQueryParams queryParams) {
+   public KeycloakResponse<RoleRepresentation[]> getRoles(String accessToken, UUID clientUuid, RoleQueryParams queryParams) {
       return keycloakRoleClient.getRoles(accessToken, clientUuid, queryParams).block();
    }
 
    @Override
-   public KeycloakResponse<RoleRepresentation[]> getUserRole(String accessToken, String userId, String clientUuid) {
+   public KeycloakResponse<RoleRepresentation[]> getUserRole(String accessToken, UUID userId, UUID clientUuid) {
       return keycloakRoleClient.getUserRole(accessToken, userId, clientUuid).block();
    }
 
    @Override
-   public KeycloakResponse<Void> grantRole(String accessToken, String userId, String clientUuid, RoleRepresentation[] role) {
+   public KeycloakResponse<Void> grantRole(String accessToken, UUID userId, UUID clientUuid, RoleRepresentation[] role) {
       return keycloakRoleClient.grantRole(accessToken, userId, clientUuid, role).block();
    }
 
    @Override
-   public KeycloakResponse<Void> removeRole(String accessToken, String userId, String clientUuid, RoleRepresentation[] role) {
+   public KeycloakResponse<Void> removeRole(String accessToken, UUID userId, UUID clientUuid, RoleRepresentation[] role) {
       return keycloakRoleClient.removeRole(accessToken, userId, clientUuid, role).block();
    }
 
    @Override
-   public KeycloakResponse<UserRepresentation[]> getUsersByClientRoleName(String accessToken, String roleName, String clientUuid,
+   public KeycloakResponse<UserRepresentation[]> getUsersByClientRoleName(String accessToken, String roleName, UUID clientUuid,
        Boolean briefRepresentation, Integer first, Integer max) {
       return keycloakRoleClient.getUsersByClientRoleName(accessToken, roleName, clientUuid, briefRepresentation, first, max).block();
    }

--- a/src/main/java/com/sd/KeycloakClient/client/admin/user/async/KeycloakAdminUserAsyncClient.java
+++ b/src/main/java/com/sd/KeycloakClient/client/admin/user/async/KeycloakAdminUserAsyncClient.java
@@ -2,6 +2,7 @@ package com.sd.KeycloakClient.client.admin.user.async;
 
 import com.sd.KeycloakClient.dto.KeycloakResponse;
 import com.sd.KeycloakClient.dto.user.UserQueryParams;
+import java.util.UUID;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import reactor.core.publisher.Mono;
@@ -42,7 +43,7 @@ public interface KeycloakAdminUserAsyncClient {
     * @param userId      the unique identifier (UUID) of the user in Keycloak
     * @return a Mono wrapping the KeycloakResponse containing the UserRepresentation if found
     */
-   Mono<KeycloakResponse<UserRepresentation>> findByUserId(String accessToken, String userId);
+   Mono<KeycloakResponse<UserRepresentation>> findByUserId(String accessToken, UUID userId);
 
    /**
     * Creates a new user in the Keycloak realm using the provided access token and user information.
@@ -67,5 +68,5 @@ public interface KeycloakAdminUserAsyncClient {
    /**
     * Set up a new password for the user.
     */
-   Mono<KeycloakResponse<Void>> resetPassword(String accessToken, String userId, CredentialRepresentation credentialRepresentation);
+   Mono<KeycloakResponse<Void>> resetPassword(String accessToken, UUID userId, CredentialRepresentation credentialRepresentation);
 }

--- a/src/main/java/com/sd/KeycloakClient/client/admin/user/async/impl/KeycloakAdminUserAsyncClientImpl.java
+++ b/src/main/java/com/sd/KeycloakClient/client/admin/user/async/impl/KeycloakAdminUserAsyncClientImpl.java
@@ -6,6 +6,7 @@ import com.sd.KeycloakClient.config.ClientConfiguration;
 import com.sd.KeycloakClient.dto.KeycloakResponse;
 import com.sd.KeycloakClient.dto.user.UserQueryParams;
 import com.sd.KeycloakClient.http.Http;
+import java.util.UUID;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import reactor.core.publisher.Mono;
@@ -47,7 +48,7 @@ public class KeycloakAdminUserAsyncClientImpl implements KeycloakAdminUserAsyncC
 
    @Override
    public Mono<KeycloakResponse<Void>> updateUserInfo(String accessToken, UserRepresentation userRepresentation) {
-      String url = configuration.getUserUrl(userRepresentation.getId());
+      String url = configuration.getUserUrl(UUID.fromString(userRepresentation.getId()));
       return http.<Void>put(url)
           .authorizationBearer(accessToken)
           .entities(userRepresentation)
@@ -57,7 +58,7 @@ public class KeycloakAdminUserAsyncClientImpl implements KeycloakAdminUserAsyncC
    }
 
    @Override
-   public Mono<KeycloakResponse<UserRepresentation>> findByUserId(String accessToken, String userId) {
+   public Mono<KeycloakResponse<UserRepresentation>> findByUserId(String accessToken, UUID userId) {
       String url = configuration.getUserUrl(userId);
       return http.<UserRepresentation>get(url)
           .authorizationBearer(accessToken)
@@ -78,7 +79,7 @@ public class KeycloakAdminUserAsyncClientImpl implements KeycloakAdminUserAsyncC
    }
 
    @Override
-   public Mono<KeycloakResponse<Void>> resetPassword(String accessToken, String userId, CredentialRepresentation credentialRepresentation) {
+   public Mono<KeycloakResponse<Void>> resetPassword(String accessToken, UUID userId, CredentialRepresentation credentialRepresentation) {
       String resetPasswordUrl = configuration.getResetPasswordUrl(userId);
       return http.<Void>put(resetPasswordUrl)
           .authorizationBearer(accessToken)

--- a/src/main/java/com/sd/KeycloakClient/client/admin/user/sync/KeycloakAdminUserClient.java
+++ b/src/main/java/com/sd/KeycloakClient/client/admin/user/sync/KeycloakAdminUserClient.java
@@ -2,6 +2,7 @@ package com.sd.KeycloakClient.client.admin.user.sync;
 
 import com.sd.KeycloakClient.dto.KeycloakResponse;
 import com.sd.KeycloakClient.dto.user.UserQueryParams;
+import java.util.UUID;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 
@@ -40,7 +41,7 @@ public interface KeycloakAdminUserClient {
     * @param accessToken the access token with sufficient privileges to access user information
     * @param userId      the unique identifier (UUID) of the user in Keycloak
     */
-   KeycloakResponse<UserRepresentation> findByUserId(String accessToken, String userId);
+   KeycloakResponse<UserRepresentation> findByUserId(String accessToken, UUID userId);
 
    /**
     * Creates a new user in the Keycloak realm using the provided access token and user information.
@@ -65,6 +66,6 @@ public interface KeycloakAdminUserClient {
    /**
     * Set up a new password for the user.
     */
-   KeycloakResponse<Void> resetPassword(String accessToken, String userId, CredentialRepresentation credentialRepresentation);
+   KeycloakResponse<Void> resetPassword(String accessToken, UUID userId, CredentialRepresentation credentialRepresentation);
 
 }

--- a/src/main/java/com/sd/KeycloakClient/client/admin/user/sync/impl/KeycloakAdminUserClientImpl.java
+++ b/src/main/java/com/sd/KeycloakClient/client/admin/user/sync/impl/KeycloakAdminUserClientImpl.java
@@ -4,6 +4,7 @@ import com.sd.KeycloakClient.client.admin.user.async.KeycloakAdminUserAsyncClien
 import com.sd.KeycloakClient.client.admin.user.sync.KeycloakAdminUserClient;
 import com.sd.KeycloakClient.dto.KeycloakResponse;
 import com.sd.KeycloakClient.dto.user.UserQueryParams;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
@@ -29,7 +30,7 @@ public class KeycloakAdminUserClientImpl implements KeycloakAdminUserClient {
    }
 
    @Override
-   public KeycloakResponse<UserRepresentation> findByUserId(String accessToken, String userId) {
+   public KeycloakResponse<UserRepresentation> findByUserId(String accessToken, UUID userId) {
       return adminUserClient.findByUserId(accessToken, userId).block();
    }
 
@@ -39,7 +40,7 @@ public class KeycloakAdminUserClientImpl implements KeycloakAdminUserClient {
    }
 
    @Override
-   public KeycloakResponse<Void> resetPassword(String accessToken, String userId, CredentialRepresentation credentialRepresentation) {
+   public KeycloakResponse<Void> resetPassword(String accessToken, UUID userId, CredentialRepresentation credentialRepresentation) {
       return adminUserClient.resetPassword(accessToken, userId, credentialRepresentation).block();
    }
 

--- a/src/main/java/com/sd/KeycloakClient/config/ClientConfiguration.java
+++ b/src/main/java/com/sd/KeycloakClient/config/ClientConfiguration.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -98,16 +99,16 @@ public class ClientConfiguration {
       return attachRelativePath(getBaseAdminPath() + CLIENTS_PATH);
    }
 
-   public String getRoleMappingPath(String userId, String clientUuid) {
-      return getBaseUserPath() + "/" + userId + ROLE_MAPPING_PATH + CLIENTS_PATH + "/" + clientUuid;
+   public String getRoleMappingPath(UUID userId, UUID clientUuid) {
+      return getBaseUserPath() + "/" + userId.toString() + ROLE_MAPPING_PATH + CLIENTS_PATH + "/" + clientUuid.toString();
    }
 
-   public String getClientsRolesPath(String clientUuid) {
-      return getBaseClientsPath() + "/" + clientUuid + ROLES_PATH;
+   public String getClientsRolesPath(UUID clientUuid) {
+      return getBaseClientsPath() + "/" + clientUuid.toString() + ROLES_PATH;
 
    }
 
-   public String getClientsRolesUsersPath(String clientUuid, String roleName, Boolean briefRepresentation, Integer first, Integer max) {
+   public String getClientsRolesUsersPath(UUID clientUuid, String roleName, Boolean briefRepresentation, Integer first, Integer max) {
       StringBuilder queryParam = new StringBuilder();
       List<String> params = new ArrayList<>();
 
@@ -131,7 +132,7 @@ public class ClientConfiguration {
       return attachQueryParam(getBaseClientsPath(), queryParam);
    }
 
-   public String getRolesUrl(String clientUuid, String queryParam) {
+   public String getRolesUrl(UUID clientUuid, String queryParam) {
       return attachQueryParam(getClientsRolesPath(clientUuid), queryParam);
    }
 
@@ -143,24 +144,24 @@ public class ClientConfiguration {
       return attachQueryParam(getBaseUserPath() + COUNT_PATH, queryParam);
    }
 
-   public String getUserUrl(String userId) {
+   public String getUserUrl(UUID userId) {
       return getBaseUserPath() + "/" + userId;
    }
 
-   public String getResetPasswordUrl(String userId) {
+   public String getResetPasswordUrl(UUID userId) {
       return getUserUrl(userId) + RESET_PASSWORD_PATH;
    }
 
    // === Authorization Scope ===
-   public String getAuthScopeUrl(String clientUuid) {
-      return getBaseClientsPath() + "/" + clientUuid + AUTHZ_PATH + RESOURCE_SERVER_PATH + SCOPE_PATH;
+   public String getAuthScopeUrl(UUID clientUuid) {
+      return getBaseClientsPath() + "/" + clientUuid.toString() + AUTHZ_PATH + RESOURCE_SERVER_PATH + SCOPE_PATH;
    }
 
-   public String getAuthScopeUrl(String clientUuid, String scopeId) {
+   public String getAuthScopeUrl(UUID clientUuid, UUID scopeId) {
       return getAuthScopeUrl(clientUuid) + "/" + scopeId;
    }
 
-   public String getAuthScopeSearchUrl(String clientUuid, String queryParam) {
+   public String getAuthScopeSearchUrl(UUID clientUuid, String queryParam) {
       return attachQueryParam(getAuthScopeUrl(clientUuid), queryParam);
    }
 }

--- a/src/test/java/com/sd/KeycloakClient/client/admin/auth/async/impl/KeycloakAuthScopeAsyncClientImplTest.java
+++ b/src/test/java/com/sd/KeycloakClient/client/admin/auth/async/impl/KeycloakAuthScopeAsyncClientImplTest.java
@@ -10,6 +10,7 @@ import com.sd.KeycloakClient.dto.admin.ScopeQueryParams;
 import com.sd.KeycloakClient.factory.KeycloakClient;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.time.Duration;
+import java.util.UUID;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,7 +33,7 @@ class KeycloakAuthScopeAsyncClientImplTest extends KeycloakShareTestContainer {
 
    private String adminAccessToken;
    private String accessToken;
-   private static final String CLIENT_UUID = "de5fe303-2e50-428e-ac72-b81d1dc5139a";
+   private static final UUID CLIENT_UUID = UUID.fromString("de5fe303-2e50-428e-ac72-b81d1dc5139a");
    private static final String TEST_SCOPE_NAME = "GET";
    private static final int EXISTED_SCOPE_COUNT = 9;
 
@@ -83,7 +84,7 @@ class KeycloakAuthScopeAsyncClientImplTest extends KeycloakShareTestContainer {
             // when
             Mono<KeycloakResponse<ScopeRepresentation>> whenGet =
                 ensureScopeId.flatMap(scopeId ->
-                    keycloakClient.authScopeAsync().getScope(accessToken, CLIENT_UUID, scopeId));
+                    keycloakClient.authScopeAsync().getScope(accessToken, CLIENT_UUID, UUID.fromString(scopeId)));
 
             // then
             StepVerifier.create(whenGet)
@@ -109,7 +110,7 @@ class KeycloakAuthScopeAsyncClientImplTest extends KeycloakShareTestContainer {
          void getScopeAccessTokenNull() {
             // given
             Mono<KeycloakResponse<ScopeRepresentation>> scope = keycloakClient.authScopeAsync()
-                .getScope(null, "prm-client", "TEST_SCOPE_ID");
+                .getScope(null, UUID.fromString("de5fe303-2e50-428e-ac72-b81d1dc5139a"), UUID.randomUUID());
             // when && then
             StepVerifier.create(scope)
                 .assertNext(response -> {
@@ -125,13 +126,13 @@ class KeycloakAuthScopeAsyncClientImplTest extends KeycloakShareTestContainer {
          void getScopeClientUuidNull() {
             // given
             Mono<KeycloakResponse<ScopeRepresentation>> scope = keycloakClient.authScopeAsync()
-                .getScope(accessToken, null, "TEST_SCOPE_ID");
+                .getScope(accessToken, null, UUID.randomUUID());
             // when && then
             StepVerifier.create(scope)
                 .assertNext(response -> {
-                   assertThat(HttpResponseStatus.NOT_FOUND.code()).isEqualTo(response.getStatus());
+                   assertThat(HttpResponseStatus.BAD_REQUEST.code()).isEqualTo(response.getStatus());
                    assertThat(response.getBody()).isEmpty();
-                   assertThat(response.getMessage()).contains("Not Found");
+                   assertThat(response.getMessage()).contains("clientUuid is required");
                 })
                 .verifyComplete();
          }
@@ -391,9 +392,9 @@ class KeycloakAuthScopeAsyncClientImplTest extends KeycloakShareTestContainer {
             // when && then
             StepVerifier.create(scopeResponse)
                 .assertNext(response -> {
-                   assertThat(HttpResponseStatus.NOT_FOUND.code()).isEqualTo(response.getStatus());
+                   assertThat(HttpResponseStatus.BAD_REQUEST.code()).isEqualTo(response.getStatus());
                    assertThat(response.getBody()).isEmpty();
-                   assertThat(response.getMessage()).contains("Not Found");
+                   assertThat(response.getMessage()).contains("clientUuid is required");
                 })
                 .verifyComplete();
          }
@@ -483,6 +484,7 @@ class KeycloakAuthScopeAsyncClientImplTest extends KeycloakShareTestContainer {
          void updateScopeWithNullAccessToken() {
             // given
             ScopeRepresentation scopeToUpdate = new ScopeRepresentation();
+            scopeToUpdate.setId(UUID.randomUUID().toString());
             scopeToUpdate.setName("ScopeToUpdate");
 
             // when
@@ -536,7 +538,7 @@ class KeycloakAuthScopeAsyncClientImplTest extends KeycloakShareTestContainer {
             Mono<KeycloakResponse<Void>> deleteScopeResponse = keycloakClient.authScopeAsync().deleteScope(
                 adminAccessToken,
                 CLIENT_UUID,
-                scopeId
+                UUID.fromString(scopeId)
             );
 
             StepVerifier.create(deleteScopeResponse)
@@ -557,7 +559,7 @@ class KeycloakAuthScopeAsyncClientImplTest extends KeycloakShareTestContainer {
          @DisplayName("case15: delete scope with null accessToken -> 401 Unauthorized")
          void deleteScopeWithNullAccessToken() {
             // given
-            String scopeId = "test-scope-id";
+            UUID scopeId = UUID.randomUUID();
 
             // when
             Mono<KeycloakResponse<Void>> deleteScopeResponse = keycloakClient.authScopeAsync().deleteScope(

--- a/src/test/java/com/sd/KeycloakClient/client/admin/role/async/impl/KeycloakRoleAsyncClientImplTest.java
+++ b/src/test/java/com/sd/KeycloakClient/client/admin/role/async/impl/KeycloakRoleAsyncClientImplTest.java
@@ -10,6 +10,7 @@ import com.sd.KeycloakClient.dto.admin.RoleQueryParams;
 import com.sd.KeycloakClient.factory.KeycloakClient;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import java.util.Arrays;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,10 +23,10 @@ import reactor.test.StepVerifier;
 class KeycloakRoleAsyncClientImplTest extends KeycloakShareTestContainer {
 
    private static KeycloakClient keycloakClient;
-   private static final String TEST_CLIENT_UUID = "de5fe303-2e50-428e-ac72-b81d1dc5139a";
-   private static final String TEST_INVALID_CLIENT_UUID = "aaaaaa-2e50-428e-ac72-b81d1dc5139a";
-   private static final String TEST_ROLE_ID = "13c39667-c8df-2d2a-15n7-v3c21700e3if";
-   private static final String TEST_GRANTED_USER = "test-user-keycloak-id2";
+   private static final UUID TEST_CLIENT_UUID = UUID.fromString("de5fe303-2e50-428e-ac72-b81d1dc5139a");
+   private static final UUID TEST_INVALID_CLIENT_UUID = UUID.fromString("aaaaaa-2e50-428e-ac72-b81d1dc5139a");
+   private static final UUID TEST_ROLE_ID = UUID.fromString("7a0c8b2d-5e9f-41a3-b0c6-3d7f4b8a2e1d");
+   private static final UUID TEST_GRANTED_USER = UUID.fromString("a9a6359c-f4a3-4268-8133-1a64a894416d");
    private static final String TEST_GRANTED_ROLE = "ADMIN";
 
    private String adminAccessToken;
@@ -86,7 +87,7 @@ class KeycloakRoleAsyncClientImplTest extends KeycloakShareTestContainer {
    void roleMapping() {
       // given
       RoleRepresentation role = new RoleRepresentation();
-      role.setId(TEST_ROLE_ID);
+      role.setId(TEST_ROLE_ID.toString());
       role.setName(TEST_GRANTED_ROLE);
 
       Mono<KeycloakResponse<Void>> grantRoleResponse = keycloakClient.roleAsync()
@@ -156,7 +157,7 @@ class KeycloakRoleAsyncClientImplTest extends KeycloakShareTestContainer {
    void grantAndRemoveRole() {
       // given
       RoleRepresentation role = new RoleRepresentation();
-      role.setId(TEST_ROLE_ID);
+      role.setId(TEST_ROLE_ID.toString());
       role.setName(TEST_GRANTED_ROLE);
 
       Mono<KeycloakResponse<Void>> grantRoleResponse = keycloakClient.roleAsync()

--- a/src/test/java/com/sd/KeycloakClient/client/admin/user/async/impl/KeycloakAdminUserAsyncClientImplTest.java
+++ b/src/test/java/com/sd/KeycloakClient/client/admin/user/async/impl/KeycloakAdminUserAsyncClientImplTest.java
@@ -10,6 +10,7 @@ import com.sd.KeycloakClient.dto.KeycloakResponse;
 import com.sd.KeycloakClient.dto.user.UserQueryParams;
 import com.sd.KeycloakClient.factory.KeycloakClient;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,7 +29,7 @@ class KeycloakAdminUserAsyncClientImplTest extends KeycloakShareTestContainer {
    private String adminAccessToken;
    private String accessToken;
 
-   private static final String TEST_USER_ID = "test-user-keycloak-id3";
+   private static final UUID TEST_USER_ID = UUID.fromString("a9a6359c-f4a3-4268-8133-1a64a894416d");
    private static final String TEST_USER_NAME = "test-user-keycloak3";
    private static final String TEST_USER_EMAIL = "test3@example.com";
    private static final String NEW_USER_EMAIL = "createnew@example.com";
@@ -221,7 +222,7 @@ class KeycloakAdminUserAsyncClientImplTest extends KeycloakShareTestContainer {
              assertThat(response.getBody()).isPresent();
 
              UserRepresentation userRepresentation = response.getBody().get();
-             assertThat(userRepresentation.getId()).isEqualTo(TEST_USER_ID);
+             assertThat(userRepresentation.getId()).isEqualTo(TEST_USER_ID.toString());
              assertThat(userRepresentation.getUsername()).isEqualTo(TEST_USER_NAME);
              assertThat(userRepresentation.getEmail()).isEqualTo(TEST_USER_EMAIL);
           }).verifyComplete();
@@ -232,7 +233,7 @@ class KeycloakAdminUserAsyncClientImplTest extends KeycloakShareTestContainer {
    void findByUserIdNotFound() {
       // when && then
       Mono<KeycloakResponse<UserRepresentation>> userInfo = keycloakClient.adminUserAsync()
-          .findByUserId(adminAccessToken, "NOT_FOUND_USER_ID");
+          .findByUserId(adminAccessToken, UUID.randomUUID());
       StepVerifier.create(userInfo)
           .assertNext(response -> {
              assertThat(HttpResponseStatus.NOT_FOUND.code()).isEqualTo(response.getStatus());

--- a/src/test/java/com/sd/KeycloakClient/config/ClientConfigurationTest.java
+++ b/src/test/java/com/sd/KeycloakClient/config/ClientConfigurationTest.java
@@ -3,6 +3,7 @@ package com.sd.KeycloakClient.config;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.sd.KeycloakClient.dto.admin.ScopeQueryParams;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -12,6 +13,7 @@ class ClientConfigurationTest {
    private static final String REALM_NAME = "test-realm";
    private static final String RELATIVE_PATH = "keycloak";
    private static final String CLIENT_ID = "de5fe303-2e50-428e-ac72-b81d1dc5139a";
+   private static final UUID CLIENT_UUID = UUID.fromString("de5fe303-2e50-428e-ac72-b81d1dc5139a");
    private static final String REDIRECT_URI = "http://localhost:8080/callback";
    private static final String LOGOUT_REDIRECT_URI = "http://localhost:8080/logout";
    private static final String RESPONSE_TYPE = "code";
@@ -31,7 +33,7 @@ class ClientConfigurationTest {
    @Test
    @DisplayName("1. should return scope URL for client")
    void getAuthScopeUrl() {
-      String url = cfg.getAuthScopeUrl(CLIENT_ID);
+      String url = cfg.getAuthScopeUrl(CLIENT_UUID);
       String expected = RELATIVE_PATH + "/admin/realms/" + REALM_NAME
           + "/clients/" + CLIENT_ID + "/authz/resource-server/scope";
       assertEquals(expected, url);
@@ -40,8 +42,8 @@ class ClientConfigurationTest {
    @Test
    @DisplayName("2. should return scope URL including scope UUID")
    void getAuthScopeUrlWithScopeUuid() {
-      String scopeUuid = "test-scope-uuid";
-      String url = cfg.getAuthScopeUrl(CLIENT_ID, scopeUuid);
+      UUID scopeUuid = UUID.randomUUID();
+      String url = cfg.getAuthScopeUrl(CLIENT_UUID, scopeUuid);
       String expected = RELATIVE_PATH + "/admin/realms/" + REALM_NAME
           + "/clients/" + CLIENT_ID + "/authz/resource-server/scope/" + scopeUuid;
       assertEquals(expected, url);
@@ -50,7 +52,7 @@ class ClientConfigurationTest {
    @Test
    @DisplayName("3. should append query params as-is to scope search URL")
    void getAuthScopeSearchUrl_withRawQueryString() {
-      String url = cfg.getAuthScopeSearchUrl(CLIENT_ID, "?name=test");
+      String url = cfg.getAuthScopeSearchUrl(CLIENT_UUID, "?name=test");
       String expected = RELATIVE_PATH + "/admin/realms/" + REALM_NAME
           + "/clients/" + CLIENT_ID + "/authz/resource-server/scope?name=test";
       assertEquals(expected, url);
@@ -60,7 +62,7 @@ class ClientConfigurationTest {
    @DisplayName("4. should append query params created by ScopeQueryParams (integration smoke)")
    void getAuthScopeSearchUrl_withScopeQueryParams() {
       String qs = ScopeQueryParams.builder().first(5).max(20).name("scopeX").build().toQueryString();
-      String url = cfg.getAuthScopeSearchUrl(CLIENT_ID, qs);
+      String url = cfg.getAuthScopeSearchUrl(CLIENT_UUID, qs);
       String expected = RELATIVE_PATH + "/admin/realms/" + REALM_NAME
           + "/clients/" + CLIENT_ID + "/authz/resource-server/scope?first=5&max=20&name=scopeX";
       assertEquals(expected, url);

--- a/src/test/resources/realm.json
+++ b/src/test/resources/realm.json
@@ -107,7 +107,7 @@
           "attributes": {}
         },
         {
-          "id": "13c39667-c8df-2d2a-15n7-v3c21700e3if",
+          "id": "7a0c8b2d-5e9f-41a3-b0c6-3d7f4b8a2e1d",
           "name": "ADMIN",
           "description": "admin role",
           "composite": false,
@@ -2701,7 +2701,7 @@
       }
     },
     {
-      "id": "test-user-keycloak-id2",
+      "id": "8b1d9c72-e5f8-4a31-b0c6-3d7f4b8a2e1d",
       "username": "test-user-keycloak2",
       "email": "test2@example.com",
       "enabled": true,
@@ -2728,7 +2728,7 @@
       }
     },
     {
-      "id": "test-user-keycloak-id3",
+      "id": "a9a6359c-f4a3-4268-8133-1a64a894416d",
       "username": "test-user-keycloak3",
       "email": "test3@example.com",
       "enabled": true,
@@ -2755,7 +2755,7 @@
       }
     },
     {
-      "id": "test-admin-user-id",
+      "id": "13c39667-c8df-2d2a-15a7-b3c21700e31f",
       "username": "test-admin-user-keycloak",
       "email": "testAdmin@example.com",
       "enabled": true,


### PR DESCRIPTION
<!-- 🔍🔍🔍 작성법 가이드 보기 🔍🔍🔍-->


## 📝 작업 내용
**작업 항목마다 한 줄로 요약하며, 필요한 경우 이유나 설명을 덧붙이세요.**
- [fix] `clientUuid`/`resourceId` 등 필수 식별자 누락 시 `400 Bad Request`로 정합성 강화(기존 일부 케이스의 404 → 400 교정)
- [refactor] Admin/User/Role/AuthScope 클라이언트 전반에 **UUID 타입** 적용(경로/파라미터 구성 메서드 포함)
- [refactor] `ClientConfiguration`의 URL 빌더 메서드 시그니처를 `UUID` 기반으로 변경 및 쿼리스트링 생성 로직 정리
- [test] 비정상 입력 케이스(토큰 blank, clientUuid null 등) 추가 및 기대 상태코드 갱신
- [test] 기존 시나리오(검색, 페이징, 특수문자 인코딩)는 리그레션 확인 완료
- [chore] `realm.json`의 테스트 데이터 UUID 정리(역할/사용자 id 고도화)

---

## 💡 리뷰 포인트 *(필수)*
**개선 의견이 필요한 부분이나 중요하게 검토해야 할 부분을 구체적으로 적으세요.**
1. **호환성(Breaking Change) 영향도**  
   - 인터페이스/구현체 전반에서 `String → UUID` 변경: 상위/호출부 영향 범위와 컴파일 브레이크 포인트가 모두 반영되었는지 확인 부탁드립니다.
2. **예외/에러 맵핑 일관성**  
   - 파라미터 누락 시 `400`, 인증 자격 미제공 시 `401` 기준이 모든 엔드포인트에 일관 적용되었는지 점검 요청드립니다.
3. **UUID 파싱 안정성**  
   - `UUID.fromString(...)` 사용 지점에서 불변성/널가드 적절성(특히 `updateScope`에서의 `scopeRepresentation.getId()` 검증)이 충분한지 확인해주세요.
4. **메시지 가독성/개발자 UX**  
   - `KeycloakResponse.fail`에 전달되는 메시지가 디버깅에 충분한지(필드명 명시, 기대 형식 안내 등) 리뷰 부탁드립니다.
5. **테스트 커버리지 적정성**  
   - 401/400 케이스 추가 외, 잘못된 UUID 포맷/존재하지 않는 리소스(정상 404) 케이스가 균형 있게 포함되었는지 확인 바랍니다.
6. **URL 빌더/쿼리스트링 회귀 방지**  
   - `ClientConfiguration` 경로/파라미터 조합 변경으로 인한 사이드이펙트(인코딩 누락/이중슬래시 등)가 없는지 검토 요청드립니다.
7. **도메인 용어/시그니처 컨벤션**  
   - sync/async 클라이언트 간 메서드명/파라미터 순서 일치 여부, `clientUuid`, `scopeId`, `userId` 네이밍 통일성 확인 부탁드립니다.

---

## 📂 변경된 파일 및 설명 *(필수)*
**변경된 파일 목록과 주요 변경 내용을 간단히 설명합니다.**
1. `src/main/java/com/sd/KeycloakClient/dto/KeycloakResponse.java`  
   - `fail(int, String)` 팩토리 메서드 추가(실패 응답 생성 통일)
2. `src/main/java/com/sd/KeycloakClient/config/ClientConfiguration.java`  
   - URL 빌더 메서드 `String → UUID` 시그니처 전환(`getRoleMappingPath`, `getClientsRolesPath`, `getClientsRolesUsersPath`, `getRolesUrl`, `getUserUrl`, `getResetPasswordUrl`, `getAuthScopeUrl` 등)
3. `src/main/java/com/sd/KeycloakClient/client/admin/auth/async/KeycloakAuthScopeAsyncClient.java` 및 `impl` / `sync` 계열  
   - 모든 메서드의 `clientUuid`, `scopeId`를 `UUID`로 변경  
   - 사전검증 추가(`clientUuid == null` → 400), `updateScope`에서 `scope id` 유효성 확인
4. `src/main/java/com/sd/KeycloakClient/client/admin/role/async/KeycloakRoleAsyncClient.java` 및 `impl` / `sync` 계열  
   - `getRoles`, `getUserRole`, `grantRole`, `removeRole`, `getUsersByClientRoleName` 등에 `UUID` 적용
5. `src/main/java/com/sd/KeycloakClient/client/admin/user/async/KeycloakAdminUserAsyncClient.java` 및 `impl` / `sync` 계열  
   - `findByUserId`, `resetPassword`, `updateUserInfo`에 `UUID` 적용(`userRepresentation.getId()` 파싱 포함)
6. `src/test/java/**/KeycloakAuthScopeAsyncClientImplTest.java`  
   - 401/400 기대값 정정(일부 404→400), blank 토큰 케이스 추가, `UUID` 기반 파라미터 반영
7. `src/test/java/**/KeycloakRoleAsyncClientImplTest.java`  
   - 테스트 상수들을 `UUID`로 교체, 역할/사용자 id 세팅 방식 정리
8. `src/test/java/**/KeycloakAdminUserAsyncClientImplTest.java`  
   - `TEST_USER_ID`를 `UUID`로 전환, 응답 검증 시 `toString()` 비교 적용
9. `src/test/java/**/ClientConfigurationTest.java`  
   - `CLIENT_UUID`를 `UUID`로 교체, 스코프 URL/검색 URL 기대값 갱신
10. `src/test/resources/realm.json`  
    - 테스트용 역할/사용자 `id`를 합리적 `UUID`로 교체하여 일관성 확보

---

## 🚨 기타 사항 *(선택)*
**리뷰어들에게 추가적으로 공유할 내용이 있다면 작성합니다.**
- 이번 변경은 **컴파일 타임**에 드러나는 시그니처 변경이므로, 상위 모듈/호출부의 `String → UUID` 전환이 필요합니다. MR 병합 전/후 체크리스트에 **호출부 점검**을 포함하였습니다.
- `404 Not Found`는 **리소스가 실제로 없을 때**에만 사용하고, **필수 파라미터 미제공/불량 포맷**은 `400 Bad Request`, **인증 자격 미제공**은 `401`로 명확히 분리했습니다.
- 로컬/CI 통합테스트는 기존 컨테이너 환경에서 이상 없음을 확인했습니다. 추가로 엣지 케이스(대용량 페이징, 특수문자 스코프명)도 유지됩니다.

